### PR TITLE
[TASK ####] Homework 8.2.

### DIFF
--- a/niffler-e-2-e-tests/build.gradle
+++ b/niffler-e-2-e-tests/build.gradle
@@ -148,5 +148,23 @@ test {
     }
     testLogging.showStandardStreams = true
     testLogging.exceptionFormat = 'full'
-    useJUnitPlatform()
+    useJUnitPlatform { excludeTags("EMPTY_DB", "FULL_DB") }
+    shouldRunAfter("dbEmpty")
+}
+
+tasks.register("dbEmpty", Test) {
+    useJUnitPlatform {
+        includeTags "EMPTY_DB"
+    }
+}
+
+tasks.register("dbFull", Test) {
+    useJUnitPlatform {
+        includeTags "FULL_DB"
+    }
+    shouldRunAfter(test)
+    /*
+    ↑ аккуратное решение;
+    простое решение — добавить @Oder(1), @Order(Integer.MAX_VALUE)/@Isolated.
+     */
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/UsersApiClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/UsersApiClient.java
@@ -15,10 +15,11 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import static guru.qa.niffler.utils.RandomDataUtils.randomUsername;
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ParametersAreNonnullByDefault
@@ -119,5 +120,22 @@ public class UsersApiClient implements UsersClient {
                 assertEquals(200, response.code());
             }
         }
+    }
+
+    @Step("Получаем список всех пользователей, кроме '{username}'")
+    public List<UserJson> getAll(String username) {
+        final Response<List<UserJson>> response;
+
+        try {
+            response = userdataApi.allUsers(username, null)
+                    .execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(200, response.code());
+
+        return response.body() != null
+                ? response.body()
+                : Collections.emptyList();
     }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/UsersClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/UsersClient.java
@@ -16,4 +16,6 @@ public interface UsersClient {
 
     void createFriends(UserJson targetUser, int count);
 
+
+
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/EmptyDBTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/EmptyDBTest.java
@@ -1,0 +1,23 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.jupiter.annotation.User;
+import guru.qa.niffler.model.UserJson;
+import guru.qa.niffler.service.UsersApiClient;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("EMPTY_DB")
+public class EmptyDBTest {
+    UsersApiClient usersApiClient = new UsersApiClient();
+
+    @User
+    @Test
+    public void shouldReturnEmptyListWhenDBIsEmpty(UserJson user) {
+        List<UserJson> users = usersApiClient.getAll(user.username());
+        assertTrue(users.isEmpty());
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/UsersApiTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/UsersApiTest.java
@@ -1,0 +1,24 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.jupiter.annotation.User;
+import guru.qa.niffler.model.UserJson;
+import guru.qa.niffler.service.UsersApiClient;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@Tag("FULL_DB")
+public class UsersApiTest {
+
+    UsersApiClient usersApiClient = new UsersApiClient();
+
+    @User
+    @Test
+    public void shouldReturnUsersWhenDBIsNotEmpty(UserJson user) {
+        List<UserJson> users = usersApiClient.getAll(user.username());
+        assertFalse(users.isEmpty());
+    }
+}


### PR DESCRIPTION
- Created new Gradle tasks (`dbEmpty`, `dbFull`) to run tests based on database states, integrated via JUnit tags (`EMPTY_DB`, `FULL_DB`).
- Updated `UsersApiClient` with a `getAll()` method for retrieving a list of users excluding a specified username, improving test support functionality.
- Added test methods in `EmptyDBTest` and `UsersApiTest` to verify the behavior of the user retrieval API under empty and populated database conditions, respectively.
- Enhanced parallel test execution configuration and added comments for clarity in Gradle build scripts.