### PR TITLE
[TASK ####] Homework 11.1

### DIFF
--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/AuthApiClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/AuthApiClient.java
@@ -1,14 +1,25 @@
 package guru.qa.niffler.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import guru.qa.niffler.api.core.ThreadSafeCookieStore;
+import guru.qa.niffler.config.Config;
+import guru.qa.niffler.jupiter.extension.TestsMethodContextExtension;
 import guru.qa.niffler.service.RestClient;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import retrofit2.Response;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ParametersAreNonnullByDefault
 public class AuthApiClient extends RestClient {
+
+    private final String URI = Config.getInstance().frontUrl() + "authorized";
+    private final String biscuit = "XSRF-TOKEN";
 
     private final AuthApi authApi;
 
@@ -24,10 +35,71 @@ public class AuthApiClient extends RestClient {
                     username,
                     password,
                     password,
-                    ThreadSafeCookieStore.INSTANCE.cookieValue("XSRF-TOKEN")
+                    ThreadSafeCookieStore.INSTANCE.cookieValue(biscuit)
             ).execute();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void preRequest(String codeChallenge) {
+        final Response response;
+
+        try {
+            response = authApi.authorize(
+                    "code",
+                    "client",
+                    "openid",
+                    URI,
+                    codeChallenge,
+                    "S256").execute();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        assertEquals(200, response.code());
+    }
+
+    public void login(String username, String password) {
+        final String code;
+
+        try {
+            code = authApi.login(
+                            username,
+                            password,
+                            ThreadSafeCookieStore.INSTANCE.cookieValue(biscuit)
+                    ).execute()
+                    .raw()
+                    .request()
+                    .url()
+                    .queryParameter("code");
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+
+        TestsMethodContextExtension.context()
+                .getStore(ExtensionContext.Namespace.create(AuthApiClient.class))
+                .put(
+                        "code",
+                        code
+                );
+    }
+
+    @Nonnull
+    public String token(String code, String codeVerifier) {
+        final Response<JsonNode> response;
+
+        try {
+            response = authApi.token(
+                    "client",
+                    URI,
+                    "authorization_code", code,
+                    codeVerifier
+
+            ).execute();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        assertEquals(200, response.code());
+        return Objects.requireNonNull(response.body()).get("id_token").asText();
     }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/OAuthTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/OAuthTest.java
@@ -1,0 +1,40 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.api.AuthApiClient;
+import guru.qa.niffler.jupiter.annotation.User;
+import guru.qa.niffler.model.UserJson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import guru.qa.niffler.jupiter.extension.TestsMethodContextExtension;
+
+
+import static guru.qa.niffler.utils.OauthUtils.generateCodeChallenge;
+import static guru.qa.niffler.utils.OauthUtils.generateCodeVerifier;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class OAuthTest {
+    private final AuthApiClient authApi = new AuthApiClient();
+
+    @User
+    @Test
+    public void oAuthTest(UserJson user) {
+        final String codeVerifier = generateCodeVerifier();
+        final String codeChallenge = generateCodeChallenge(codeVerifier);
+
+        authApi.preRequest(codeChallenge);
+        authApi.login(user.username(), user.testData().password());
+
+        String code = (String) TestsMethodContextExtension.context()
+                .getStore(ExtensionContext.Namespace.create(AuthApiClient.class))
+                .get("code");
+
+        String token = authApi.token(
+                code,
+                codeVerifier
+        );
+
+        assertNotNull(token);
+        System.out.println(token);
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/utils/OauthUtils.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/utils/OauthUtils.java
@@ -1,0 +1,33 @@
+package guru.qa.niffler.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class OauthUtils {
+
+    public static String generateCodeVerifier() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] codeVerifier = new byte[32];
+        secureRandom.nextBytes(codeVerifier);
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(codeVerifier);
+    }
+
+    public static String generateCodeChallenge(String codeVerifier) {
+        MessageDigest messageDigest;
+        byte[] bytes;
+        try {
+            bytes = codeVerifier.getBytes("US-ASCII");
+            messageDigest = MessageDigest.getInstance("SHA-256");
+        } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        messageDigest.update(bytes, 0, bytes.length);
+        byte[] digest = messageDigest.digest();
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+    }
+}


### PR DESCRIPTION
- Added OAuth 2.0 PKCE (Proof Key for Code Exchange) support with methods `preRequest`, `login`, and `token` in `AuthApiClient`.
- Created utility methods (`generateCodeVerifier`, `generateCodeChallenge`) in `OauthUtils` to generate PKCE parameters.
- Implemented end-to-end OAuth test (`OAuthTest`) to verify successful authentication token retrieval.
- Enhanced `UsersApiClient` with `getAll` method for retrieving user lists.