### PR TITLE
[TASK ####] homework 17-2

### DIFF
--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/Config.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/Config.java
@@ -41,4 +41,17 @@ public interface Config {
     default String ghUrl() {
         return "https://api.github.com/";
     }
+
+    @Nonnull
+    String currencyGrpcAddress();
+    default int currencyGrpcPort() {
+        return 8092;
+    }
+
+    @Nonnull
+    String userdataGrpcAddress();
+
+    default int userdataGrpcPort() {
+        return 8094;
+    }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/DockerConfig.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/DockerConfig.java
@@ -1,5 +1,7 @@
 package guru.qa.niffler.config;
 
+import org.jetbrains.annotations.NotNull;
+
 import javax.annotation.Nonnull;
 
 enum DockerConfig implements Config {
@@ -56,6 +58,17 @@ enum DockerConfig implements Config {
     @Nonnull
     @Override
     public String currencyJdbcUrl() {
+        return "";
+    }
+    @NotNull
+    @Override
+    public String currencyGrpcAddress() {
+        return "";
+    }
+
+    @NotNull
+    @Override
+    public String userdataGrpcAddress() {
         return "";
     }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/LocalConfig.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/config/LocalConfig.java
@@ -1,6 +1,8 @@
 package guru.qa.niffler.config;
 
 
+import org.jetbrains.annotations.NotNull;
+
 import javax.annotation.Nonnull;
 
 enum LocalConfig implements Config {
@@ -58,5 +60,16 @@ enum LocalConfig implements Config {
     @Override
     public String currencyJdbcUrl() {
         return "jdbc:postgresql://127.0.0.1:5432/niffler-currency";
+    }
+    @NotNull
+    @Override
+    public String currencyGrpcAddress() {
+        return "127.0.0.1";
+    }
+
+    @NotNull
+    @Override
+    public String userdataGrpcAddress() {
+        return "127.0.0.1";
     }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/jupiter/annotation/meta/GrpcTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/jupiter/annotation/meta/GrpcTest.java
@@ -1,0 +1,23 @@
+package guru.qa.niffler.jupiter.annotation.meta;
+
+import guru.qa.niffler.jupiter.extension.CategoryExtension;
+import guru.qa.niffler.jupiter.extension.SpendingExtension;
+import guru.qa.niffler.jupiter.extension.UserExtension;
+import io.qameta.allure.junit5.AllureJunit5;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith({
+        AllureJunit5.class,
+        UserExtension.class,
+        CategoryExtension.class,
+        SpendingExtension.class,
+})
+public @interface GrpcTest {
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/BaseGrpcTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/BaseGrpcTest.java
@@ -1,0 +1,32 @@
+package guru.qa.niffler.test.grpc;
+
+import guru.qa.niffler.config.Config;
+import guru.qa.niffler.grpc.NifflerCurrencyServiceGrpc;
+import guru.qa.niffler.grpc.NifflerUserdataServiceGrpc;
+import guru.qa.niffler.jupiter.annotation.meta.GrpcTest;
+import guru.qa.niffler.utils.GrpcConsoleInterceptor;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+
+@GrpcTest
+public class BaseGrpcTest {
+
+    protected static final Config CFG = Config.getInstance();
+
+    protected static final Channel currencyChannel = ManagedChannelBuilder
+            .forAddress(CFG.currencyGrpcAddress(), CFG.currencyGrpcPort())
+            .intercept(new GrpcConsoleInterceptor())
+            .usePlaintext()
+            .build();
+
+    protected static final Channel udChannel = ManagedChannelBuilder
+            .forAddress(CFG.userdataGrpcAddress(), CFG.userdataGrpcPort())
+            .intercept(new GrpcConsoleInterceptor())
+            .usePlaintext()
+            .build();
+
+    protected static final NifflerCurrencyServiceGrpc.NifflerCurrencyServiceBlockingStub blockingStub
+            = NifflerCurrencyServiceGrpc.newBlockingStub(currencyChannel);
+    protected static final NifflerUserdataServiceGrpc.NifflerUserdataServiceBlockingStub userdataBlockingStub
+            = NifflerUserdataServiceGrpc.newBlockingStub(udChannel);
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/CurrencyGrpcTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/CurrencyGrpcTest.java
@@ -1,0 +1,67 @@
+package guru.qa.niffler.test.grpc;
+
+import com.google.protobuf.Empty;
+import guru.qa.niffler.grpc.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class CurrencyGrpcTest extends BaseGrpcTest {
+
+    @Test
+    void allCurrenciesShouldReturned() {
+        final CurrencyResponse response = blockingStub.getAllCurrencies(Empty.getDefaultInstance());
+        final List<Currency> allCurrenciesList = response.getAllCurrenciesList();
+        Assertions.assertEquals(4, allCurrenciesList.size());
+    }
+
+    static Stream<Arguments> calculatedRateDataProvider() {
+        return Stream.of(Arguments.arguments(CurrencyValues.USD, 1000.00, 15.0),
+                Arguments.arguments(CurrencyValues.KZT, 2000.00, 14285.71),
+                Arguments.arguments(CurrencyValues.EUR, 500, 6.94)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("calculatedRateDataProvider")
+    void shouldCalculateAmountForSpendsInRUB(CurrencyValues targetCurrency,
+                                             double amount,
+                                             double expectedValue) {
+        final CalculateRequest request = CalculateRequest.newBuilder()
+                .setAmount(amount)
+                .setSpendCurrency(CurrencyValues.RUB)
+                .setDesiredCurrency(targetCurrency)
+                .build();
+        final CalculateResponse calculateResponse = blockingStub.calculateRate(request);
+        Assertions.assertEquals(BigDecimal.valueOf(expectedValue), calculateResponse.getCalculatedAmount());
+    }
+
+    static Stream<Arguments> calculatedRateForMinSpendDataProvider() {
+        return Stream.of(
+                Arguments.arguments(CurrencyValues.USD, 0.0),
+                Arguments.arguments(CurrencyValues.KZT, 0.07),
+                Arguments.arguments(CurrencyValues.EUR, 0.0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("calculatedRateForMinSpendDataProvider")
+    void shouldCalculateAmountForMinSpendsInRUB(CurrencyValues targetCurrency,
+                                                double expectedValue) {
+        final double amount = 0.01;
+        final CalculateRequest request = CalculateRequest.newBuilder()
+                .setAmount(amount)
+                .setSpendCurrency(CurrencyValues.RUB)
+                .setDesiredCurrency(targetCurrency)
+                .build();
+        final CalculateResponse calculateResponse = blockingStub.calculateRate(request);
+        Assertions.assertEquals(expectedValue, calculateResponse.getCalculatedAmount());
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/UserdataGrpcTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/grpc/UserdataGrpcTest.java
@@ -1,0 +1,125 @@
+package guru.qa.niffler.test.grpc;
+
+
+import guru.qa.niffler.grpc.*;
+import guru.qa.niffler.jupiter.annotation.User;
+import guru.qa.niffler.model.rest.UserJson;
+import org.junit.jupiter.api.Test;
+
+import static guru.qa.niffler.model.FriendshipStatus.INVITE_SENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserdataGrpcTest extends BaseGrpcTest {
+
+    @Test
+    @User(friends = 5)
+    void shouldReturnFriendsListPage(UserJson user) {
+        final UserPageRequest request = UserPageRequest.newBuilder()
+                .setUsername(user.username())
+                .setPage(0)
+                .setSize(10)
+                .build();
+        UserPageResponse userPageResponse = userdataBlockingStub.friendsPage(request);
+        assertEquals(5, userPageResponse.getEdgesCount());
+        assertEquals(5, userPageResponse.getTotalElements());
+        assertEquals(1, userPageResponse.getTotalPages());
+    }
+
+    @Test
+    @User(friends = 5)
+    void shouldReturnFriendFilteredByUsername(UserJson user) {
+        final String expectedUsername = user.testData().friendsUsernames()[0];
+        final UserPageRequest request = UserPageRequest.newBuilder()
+                .setUsername(user.username())
+                .setPage(0)
+                .setSize(10)
+                .setSearchQuery(expectedUsername)
+                .build();
+        UserPageResponse userPageResponse = userdataBlockingStub.friendsPage(request);
+        assertEquals(expectedUsername, userPageResponse.getEdgesList().getFirst().getUsername());
+        assertEquals(1, userPageResponse.getEdgesCount());
+    }
+
+    @Test
+    @User(friends = 1)
+    void shouldRemoveFriendship(UserJson user) {
+        final String friendToRemove = user.testData().friendsUsernames()[0];
+        final FriendshipRequest removeRequest = FriendshipRequest.newBuilder()
+                .setUsername(user.username())
+                .setTargetUsername(friendToRemove)
+                .build();
+        userdataBlockingStub.removeFriend(removeRequest);
+
+        final UserBulkRequest request = UserBulkRequest.newBuilder()
+                .setUsername(user.username())
+                .setSearchQuery(friendToRemove)
+                .build();
+        UsersBulkResponse userPageResponse = userdataBlockingStub.friends(request);
+        assertEquals(0, userPageResponse.getUserForBulkResponseList().size());
+    }
+
+    @Test
+    @User(incomeInvitations = 1)
+    void shouldAcceptFriendship(UserJson user) {
+        final UserJson friendToAccept = user.testData().incomeInvitations().get(0);
+        final FriendshipRequest removeRequest = FriendshipRequest.newBuilder()
+                .setUsername(user.username())
+                .setTargetUsername(friendToAccept.username())
+                .build();
+        userdataBlockingStub.acceptFriendshipRequest(removeRequest);
+
+        final UserBulkRequest request = UserBulkRequest.newBuilder()
+                .setUsername(user.username())
+                .setSearchQuery(friendToAccept.username())
+                .build();
+        UsersBulkResponse userPageResponse = userdataBlockingStub.friends(request);
+        assertEquals(
+                friendToAccept.username(),
+                userPageResponse.getUserForBulkResponseList().get(0).getUsername()
+        );
+    }
+
+    @Test
+    @User(incomeInvitations = 1)
+    void shouldDeclineFriendship(UserJson user) {
+        final UserJson friendToDecline = user.testData().incomeInvitations().get(0);
+        final FriendshipRequest removeRequest = FriendshipRequest.newBuilder()
+                .setUsername(user.username())
+                .setTargetUsername(friendToDecline.username())
+                .build();
+        userdataBlockingStub.declineFriendshipRequest(removeRequest);
+
+        final UserBulkRequest request = UserBulkRequest.newBuilder()
+                .setUsername(user.username())
+                .setSearchQuery(friendToDecline.username())
+                .build();
+        UsersBulkResponse userPageResponse = userdataBlockingStub.friends(request);
+        assertEquals(0, userPageResponse.getUserForBulkResponseList().size());
+    }
+
+    @Test
+    @User
+    void sendFriendshipRequest(UserJson user) {
+        final UserPageRequest allUsersRequest = UserPageRequest.newBuilder()
+                .setUsername(user.username())
+                .setPage(2)
+                .setSize(1)
+                .build();
+
+        String targetUsername = userdataBlockingStub.allUsersPage(allUsersRequest)
+                .getEdgesList()
+                .getLast()
+                .getUsername();
+
+        final FriendshipRequest friendshipRequest = FriendshipRequest.newBuilder()
+                .setUsername(user.username())
+                .setTargetUsername(targetUsername)
+                .build();
+        UserResponse targetUserResponse = userdataBlockingStub.createFriendshipRequest(friendshipRequest);
+
+        assertEquals(user.username(), targetUserResponse.getUsername());
+        assertEquals(FriendshipStatus.valueOf(INVITE_SENT.name()),
+                targetUserResponse.getFriendshipStatus());
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/utils/GrpcConsoleInterceptor.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/utils/GrpcConsoleInterceptor.java
@@ -1,0 +1,51 @@
+package guru.qa.niffler.utils;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+import io.grpc.*;
+
+public class GrpcConsoleInterceptor implements io.grpc.ClientInterceptor {
+
+    private static final JsonFormat.Printer printer = JsonFormat.printer();
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+        return new ForwardingClientCall.SimpleForwardingClientCall(
+                channel.newCall(methodDescriptor, callOptions)
+        ) {
+
+            @Override
+            public void sendMessage(Object message) {
+                try {
+                    System.out.println("REQUEST: " + printer.print((MessageOrBuilder) message));
+                } catch (InvalidProtocolBufferException e) {
+                    throw new RuntimeException(e);
+                }
+                super.sendMessage(message);
+            }
+
+            @Override
+            public void start(Listener responseListener, Metadata headers) {
+                ForwardingClientCallListener<Object> clientCallListener = new ForwardingClientCallListener<>() {
+
+                    @Override
+                    public void onMessage(Object message) {
+                        try {
+                            System.out.println("RESPONSE: " + printer.print((MessageOrBuilder) message));
+                        } catch (InvalidProtocolBufferException e) {
+                            throw new RuntimeException(e);
+                        }
+                        super.onMessage(message);
+                    }
+
+                    @Override
+                    protected Listener<Object> delegate() {
+                        return responseListener;
+                    }
+                };
+                super.start(clientCallListener, headers);
+            }
+        };
+    }
+}

--- a/niffler-grpc-common/src/main/proto/niffler-userdata.proto
+++ b/niffler-grpc-common/src/main/proto/niffler-userdata.proto
@@ -1,0 +1,96 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "niffler-currency.proto";
+
+package guru.qa.grpc.niffler;
+
+option java_multiple_files = true;
+option java_package = "guru.qa.niffler.grpc";
+option java_outer_classname = "NifflerUserdataProto";
+
+service NifflerUserdataService {
+  rpc Update(UserRequest) returns (UserResponse) {}
+  rpc GetCurrentUser(UsernameRequest) returns (UserResponse) {}
+  rpc AllUsers(UserBulkRequest) returns (UsersBulkResponse) {}
+  rpc AllUsersPage(UserPageRequest) returns (UserPageResponse) {}
+  rpc Friends(UserBulkRequest) returns (UsersBulkResponse) {}
+  rpc FriendsPage(UserPageRequest) returns (UserPageResponse) {}
+  rpc CreateFriendshipRequest(FriendshipRequest) returns (UserResponse) {}
+  rpc AcceptFriendshipRequest(FriendshipRequest) returns (UserResponse) {}
+  rpc DeclineFriendshipRequest(FriendshipRequest) returns (UserResponse) {}
+  rpc RemoveFriend(FriendshipRequest) returns (google.protobuf.Empty) {}
+}
+
+message UserRequest {
+  string id = 1;
+  string username = 2;
+  string firstname = 3;
+  string surname = 4;
+  string fullname = 5;
+  CurrencyValues currency = 6;
+  string photo = 7;
+  string photoSmall = 8;
+  FriendshipStatus friendshipStatus = 9;
+}
+
+message UserResponse {
+  string id = 1;
+  string username = 2;
+  string firstname = 3;
+  string surname = 4;
+  string fullname = 5;
+  CurrencyValues currency = 6;
+  string photo = 7;
+  string photoSmall = 8;
+  FriendshipStatus friendshipStatus = 9;
+}
+
+message UsernameRequest {
+  string username = 1;
+}
+
+message UserBulkRequest {
+  string username = 1;
+  optional string searchQuery = 2;
+}
+
+message UsersBulkResponse {
+  repeated UserForBulkResponse userForBulkResponse = 1;
+}
+
+message UserForBulkResponse {
+  string id = 1;
+  string username = 2;
+  string fullname = 3;
+  CurrencyValues currency = 4;
+  string photoSmall = 5;
+  FriendshipStatus friendshipStatus = 6;
+}
+
+message UserPageRequest {
+  string username = 1;
+  int32 page = 2;
+  int32 size = 3;
+  optional string searchQuery = 4;
+}
+message UserPageResponse {
+  int64 totalElements = 1;
+  int32 totalPages = 2;
+  bool first = 3;
+  bool last = 4;
+  int32 size = 5;
+  repeated UserForBulkResponse edges = 6;
+}
+
+message FriendshipRequest {
+    string username = 1;
+    string targetUsername = 2;
+}
+
+enum FriendshipStatus {
+  UNDEFINED = 0;
+  INVITE_SENT = 1;
+  INVITE_RECEIVED = 2;
+  FRIEND = 3;
+}

--- a/niffler-userdata/src/main/java/guru/qa/niffler/data/UserEntity.java
+++ b/niffler-userdata/src/main/java/guru/qa/niffler/data/UserEntity.java
@@ -1,28 +1,14 @@
 package guru.qa.niffler.data;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import guru.qa.niffler.grpc.UserResponse;
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.proxy.HibernateProxy;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 
 @Getter
@@ -30,100 +16,118 @@ import java.util.stream.Stream;
 @Entity
 @Table(name = "\"user\"")
 public class UserEntity implements Serializable {
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  @Column(name = "id", nullable = false, columnDefinition = "UUID default gen_random_uuid()")
-  private UUID id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false, columnDefinition = "UUID default gen_random_uuid()")
+    private UUID id;
 
-  @Column(nullable = false, unique = true)
-  private String username;
+    @Column(nullable = false, unique = true)
+    private String username;
 
-  @Column(nullable = false)
-  @Enumerated(EnumType.STRING)
-  private CurrencyValues currency;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CurrencyValues currency;
 
-  @Column()
-  private String firstname;
+    @Column()
+    private String firstname;
 
-  @Column()
-  private String surname;
+    @Column()
+    private String surname;
 
-  @Column(name = "full_name")
-  private String fullname;
+    @Column(name = "full_name")
+    private String fullname;
 
-  @Column(name = "photo", columnDefinition = "bytea")
-  private byte[] photo;
+    @Column(name = "photo", columnDefinition = "bytea")
+    private byte[] photo;
 
-  @Column(name = "photo_small", columnDefinition = "bytea")
-  private byte[] photoSmall;
+    @Column(name = "photo_small", columnDefinition = "bytea")
+    private byte[] photoSmall;
 
-  @OneToMany(mappedBy = "requester", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<FriendshipEntity> friendshipRequests = new ArrayList<>();
+    @OneToMany(mappedBy = "requester", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FriendshipEntity> friendshipRequests = new ArrayList<>();
 
-  @OneToMany(mappedBy = "addressee", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<FriendshipEntity> friendshipAddressees = new ArrayList<>();
+    @OneToMany(mappedBy = "addressee", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FriendshipEntity> friendshipAddressees = new ArrayList<>();
 
-  public void addFriends(FriendshipStatus status, UserEntity... friends) {
-    List<FriendshipEntity> friendsEntities = Stream.of(friends)
-        .map(f -> {
-          FriendshipEntity fe = new FriendshipEntity();
-          fe.setRequester(this);
-          fe.setAddressee(f);
-          fe.setStatus(status);
-          fe.setCreatedDate(new Date());
-          return fe;
-        }).toList();
-    this.friendshipRequests.addAll(friendsEntities);
-  }
-
-  public void addInvitations(UserEntity... invitations) {
-    List<FriendshipEntity> invitationsEntities = Stream.of(invitations)
-        .map(i -> {
-          FriendshipEntity fe = new FriendshipEntity();
-          fe.setRequester(i);
-          fe.setAddressee(this);
-          fe.setStatus(FriendshipStatus.PENDING);
-          fe.setCreatedDate(new Date());
-          return fe;
-        }).toList();
-    this.friendshipAddressees.addAll(invitationsEntities);
-  }
-
-  public void removeFriends(UserEntity... friends) {
-    List<UUID> idsToBeRemoved = Arrays.stream(friends).map(UserEntity::getId).toList();
-    for (Iterator<FriendshipEntity> i = getFriendshipRequests().iterator(); i.hasNext(); ) {
-      FriendshipEntity friendsEntity = i.next();
-      if (idsToBeRemoved.contains(friendsEntity.getAddressee().getId())) {
-        friendsEntity.setAddressee(null);
-        i.remove();
-      }
+    public void addFriends(FriendshipStatus status, UserEntity... friends) {
+        List<FriendshipEntity> friendsEntities = Stream.of(friends)
+                .map(f -> {
+                    FriendshipEntity fe = new FriendshipEntity();
+                    fe.setRequester(this);
+                    fe.setAddressee(f);
+                    fe.setStatus(status);
+                    fe.setCreatedDate(new Date());
+                    return fe;
+                }).toList();
+        this.friendshipRequests.addAll(friendsEntities);
     }
-  }
 
-  public void removeInvites(UserEntity... invitations) {
-    List<UUID> idsToBeRemoved = Arrays.stream(invitations).map(UserEntity::getId).toList();
-    for (Iterator<FriendshipEntity> i = getFriendshipAddressees().iterator(); i.hasNext(); ) {
-      FriendshipEntity friendsEntity = i.next();
-      if (idsToBeRemoved.contains(friendsEntity.getRequester().getId())) {
-        friendsEntity.setRequester(null);
-        i.remove();
-      }
+    public void addInvitations(UserEntity... invitations) {
+        List<FriendshipEntity> invitationsEntities = Stream.of(invitations)
+                .map(i -> {
+                    FriendshipEntity fe = new FriendshipEntity();
+                    fe.setRequester(i);
+                    fe.setAddressee(this);
+                    fe.setStatus(FriendshipStatus.PENDING);
+                    fe.setCreatedDate(new Date());
+                    return fe;
+                }).toList();
+        this.friendshipAddressees.addAll(invitationsEntities);
     }
-  }
 
-  @Override
-  public final boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null) return false;
-    Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
-    Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
-    if (thisEffectiveClass != oEffectiveClass) return false;
-    UserEntity that = (UserEntity) o;
-    return getId() != null && Objects.equals(getId(), that.getId());
-  }
+    public void removeFriends(UserEntity... friends) {
+        List<UUID> idsToBeRemoved = Arrays.stream(friends).map(UserEntity::getId).toList();
+        for (Iterator<FriendshipEntity> i = getFriendshipRequests().iterator(); i.hasNext(); ) {
+            FriendshipEntity friendsEntity = i.next();
+            if (idsToBeRemoved.contains(friendsEntity.getAddressee().getId())) {
+                friendsEntity.setAddressee(null);
+                i.remove();
+            }
+        }
+    }
 
-  @Override
-  public final int hashCode() {
-    return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
-  }
+    public void removeInvites(UserEntity... invitations) {
+        List<UUID> idsToBeRemoved = Arrays.stream(invitations).map(UserEntity::getId).toList();
+        for (Iterator<FriendshipEntity> i = getFriendshipAddressees().iterator(); i.hasNext(); ) {
+            FriendshipEntity friendsEntity = i.next();
+            if (idsToBeRemoved.contains(friendsEntity.getRequester().getId())) {
+                friendsEntity.setRequester(null);
+                i.remove();
+            }
+        }
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        UserEntity that = (UserEntity) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
+
+    public static @Nonnull UserResponse toUserResponse(UserEntity userEntity) {
+        return toUserResponse(userEntity, FriendshipStatus.UNDEFINED);
+    }
+
+    public static @Nonnull UserResponse toUserResponse(UserEntity userEntity, guru.qa.niffler.grpc.FriendshipStatus friendshipStatus) {
+        return UserResponse.newBuilder()
+                .setId(userEntity.getId().toString())
+                .setUsername(userEntity.getUsername())
+                .setFirstname(userEntity.getFirstname() != null ? userEntity.getFirstname() : "")
+                .setSurname(userEntity.getSurname() != null ? userEntity.getSurname() : "")
+                .setFullname(userEntity.getFullname() != null ? userEntity.getFullname() : "")
+                .setCurrency(guru.qa.niffler.grpc.CurrencyValues.valueOf(userEntity.getCurrency().name()))
+                .setPhoto(userEntity.getPhoto() != null && userEntity.getPhoto().length > 0 ? new String(userEntity.getPhoto(), StandardCharsets.UTF_8) : "")
+                .setPhotoSmall(userEntity.getPhotoSmall() != null && userEntity.getPhotoSmall().length > 0 ? new String(userEntity.getPhotoSmall(), StandardCharsets.UTF_8) : "")
+                .setFriendshipStatus(friendshipStatus)
+                .build();
+    }
 }

--- a/niffler-userdata/src/main/java/guru/qa/niffler/data/projection/UserWithStatus.java
+++ b/niffler-userdata/src/main/java/guru/qa/niffler/data/projection/UserWithStatus.java
@@ -6,11 +6,21 @@ import guru.qa.niffler.data.FriendshipStatus;
 import java.util.UUID;
 
 public record UserWithStatus(
-    UUID id,
-    String username,
-    CurrencyValues currency,
-    String fullname,
-    byte[] photoSmall,
-    FriendshipStatus status
+        UUID id,
+        String username,
+        CurrencyValues currency,
+        String fullname,
+        byte[] photoSmall,
+        FriendshipStatus status
 ) {
+    public static UserForBulkResponse toUserForBulkResponse(UserWithStatus userWithStatus) {
+        return UserForBulkResponse.newBuilder()
+                .setId(userWithStatus.id().toString())
+                .setUsername(userWithStatus.username())
+                .setFullname(userWithStatus.fullname() != null ? userWithStatus.fullname() : "")
+                .setCurrency(guru.qa.niffler.grpc.CurrencyValues.valueOf(userWithStatus.currency().name()))
+                .setPhotoSmall(userWithStatus.photoSmall() != null && userWithStatus.photoSmall().length > 0 ? new String(userWithStatus.photoSmall(), StandardCharsets.UTF_8) : "")
+                .setFriendshipStatus(guru.qa.niffler.grpc.FriendshipStatus.UNDEFINED)
+                .build();
+    }
 }

--- a/niffler-userdata/src/main/java/guru/qa/niffler/service/GrpcUserdataService.java
+++ b/niffler-userdata/src/main/java/guru/qa/niffler/service/GrpcUserdataService.java
@@ -1,0 +1,254 @@
+package guru.qa.niffler.service;
+
+import com.google.protobuf.Empty;
+import guru.qa.niffler.data.FriendshipEntity;
+import guru.qa.niffler.data.UserEntity;
+import guru.qa.niffler.data.projection.UserWithStatus;
+import guru.qa.niffler.data.repository.UserRepository;
+import guru.qa.niffler.ex.NotFoundException;
+import guru.qa.niffler.ex.SameUsernameException;
+import guru.qa.niffler.grpc.*;
+import io.grpc.stub.StreamObserver;
+import jakarta.annotation.Nonnull;
+import net.devh.boot.grpc.server.service.GrpcService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static guru.qa.niffler.data.UserEntity.toUserResponse;
+import static sun.java2d.marlin.CollinearSimplifier.SimplifierState.Empty;
+
+@GrpcService
+public class GrpcUserdataService extends NifflerUserdataServiceGrpc.NifflerUserdataServiceImplBase {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public GrpcUserdataService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void update(UserRequest request, StreamObserver<UserResponse> responseObserver) {
+        UserEntity ueToUpdate = userRepository.findByUsername(request.getUsername()).orElseThrow(
+                () -> new NotFoundException("User" + request.getUsername() + " not found")
+        );
+        ueToUpdate.setId(ueToUpdate.getId());
+        ueToUpdate.setUsername(ueToUpdate.getUsername());
+        ueToUpdate.setCurrency(ueToUpdate.getCurrency());
+        ueToUpdate.setFullname(request.getFullname());
+        ueToUpdate.setFirstname(request.getFirstname());
+        ueToUpdate.setSurname(request.getSurname());
+        ueToUpdate.setPhoto(!request.getPhoto().isEmpty() ? request.getPhoto().getBytes(StandardCharsets.UTF_8) : null);
+        ueToUpdate.setPhotoSmall(!request.getPhoto().isEmpty() ? new SmallPhoto(100, 100, request.getPhoto()).bytes() : null);
+
+        UserEntity saved = userRepository.save(ueToUpdate);
+
+        responseObserver.onNext(
+                toUserResponse(saved)
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getCurrentUser(UsernameRequest request, StreamObserver<UserResponse> responseObserver) {
+        UserEntity userEntity = userRepository.findByUsername(request.getUsername()).orElseThrow(
+                () -> new NotFoundException("User" + request.getUsername() + " not found")
+        );
+        responseObserver.onNext(
+                UserResponse.newBuilder()
+                        .setId(userEntity.getId().toString())
+                        .setUsername(userEntity.getUsername())
+                        .setFirstname(userEntity.getFirstname() != null ? userEntity.getFirstname() : "")
+                        .setSurname(userEntity.getSurname() != null ? userEntity.getSurname() : "")
+                        .setFullname(userEntity.getFullname() != null ? userEntity.getFullname() : "")
+                        .setCurrency(CurrencyValues.valueOf(userEntity.getCurrency().name()))
+                        .setPhoto(userEntity.getPhoto() != null && userEntity.getPhoto().length > 0 ? new String(userEntity.getPhoto(), StandardCharsets.UTF_8) : "")
+                        .setPhotoSmall(userEntity.getPhotoSmall() != null && userEntity.getPhotoSmall().length > 0 ? new String(userEntity.getPhotoSmall(), StandardCharsets.UTF_8) : "")
+                        .setFriendshipStatus(FriendshipStatus.UNDEFINED)
+                        .build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void allUsers(UserBulkRequest request, StreamObserver<UsersBulkResponse> responseObserver) {
+        responseObserver.onNext(
+                UsersBulkResponse.newBuilder()
+                        .addAllUserForBulkResponse(
+                                userRepository.findByUsernameNot(
+                                                request.getUsername(),
+                                                request.getSearchQuery()
+                                        )
+                                        .stream()
+                                        .map(UserWithStatus::toUserForBulkResponse)
+                                        .collect(Collectors.toList())
+                        )
+                        .build()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void allUsersPage(UserPageRequest request, StreamObserver<UserPageResponse> responseObserver) {
+        Page<UserWithStatus> users = userRepository.findByUsernameNot(
+                request.getUsername(),
+                request.getSearchQuery(),
+                PageRequest.of(request.getPage(), request.getSize())
+        );
+        responseObserver.onNext(
+                UserPageResponse.newBuilder()
+                        .addAllEdges(
+                                users.stream()
+                                        .map(UserWithStatus::toUserForBulkResponse)
+                                        .collect(Collectors.toList())
+                        )
+                        .setTotalElements(users.getNumberOfElements())
+                        .setTotalPages(users.getTotalPages())
+                        .setFirst(users.isFirst())
+                        .setLast(users.isLast())
+                        .setSize(request.getSize())
+                        .build()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void friends(UserBulkRequest request, StreamObserver<UsersBulkResponse> responseObserver) {
+        responseObserver.onNext(
+                UsersBulkResponse.newBuilder()
+                        .addAllUserForBulkResponse(
+                                userRepository.findFriends(
+                                                userRepository.findByUsername(request.getUsername()).orElseThrow(),
+                                                request.getSearchQuery()
+                                        ).stream()
+                                        .map(UserWithStatus::toUserForBulkResponse)
+                                        .collect(Collectors.toList())
+                        )
+                        .build()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void friendsPage(UserPageRequest request, StreamObserver<UserPageResponse> responseObserver) {
+        Page<UserWithStatus> friends = userRepository.findFriends(
+                userRepository.findByUsername(request.getUsername()).orElseThrow(),
+                request.getSearchQuery(),
+                PageRequest.of(request.getPage(), request.getSize())
+        );
+        responseObserver.onNext(
+                UserPageResponse.newBuilder()
+                        .addAllEdges(
+                                friends.stream()
+                                        .map(UserWithStatus::toUserForBulkResponse)
+                                        .collect(Collectors.toList())
+                        )
+                        .setTotalElements(friends.getNumberOfElements())
+                        .setTotalPages(friends.getTotalPages())
+                        .setFirst(friends.isFirst())
+                        .setLast(friends.isLast())
+                        .setSize(request.getSize())
+                        .build()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Transactional
+    @Override
+    public void createFriendshipRequest(FriendshipRequest request, StreamObserver<UserResponse> responseObserver) {
+        if (Objects.equals(request.getUsername(), request.getTargetUsername())) {
+            throw new SameUsernameException("Can`t create friendship request for self user");
+        }
+        UserEntity currentUser = getRequiredUser(request.getUsername());
+        UserEntity targetUser = getRequiredUser(request.getTargetUsername());
+        currentUser.addFriends(guru.qa.niffler.data.FriendshipStatus.PENDING, targetUser);
+        UserEntity saved = userRepository.save(currentUser);
+
+        responseObserver.onNext(
+                toUserResponse(saved, FriendshipStatus.INVITE_SENT)
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Transactional
+    @Override
+    public void acceptFriendshipRequest(FriendshipRequest request, StreamObserver<UserResponse> responseObserver) {
+        if (Objects.equals(request.getUsername(), request.getTargetUsername())) {
+            throw new SameUsernameException("Can`t accept friendship request for self user");
+        }
+        UserEntity currentUser = getRequiredUser(request.getUsername());
+        UserEntity targetUser = getRequiredUser(request.getTargetUsername());
+
+        FriendshipEntity invite = currentUser.getFriendshipAddressees()
+                .stream()
+                .filter(fe -> fe.getRequester().equals(targetUser))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Can`t find invitation from username: '" + request.getTargetUsername() + "'"));
+
+        invite.setStatus(guru.qa.niffler.data.FriendshipStatus.ACCEPTED);
+        currentUser.addFriends(guru.qa.niffler.data.FriendshipStatus.ACCEPTED, targetUser);
+        UserEntity saved = userRepository.save(currentUser);
+
+        responseObserver.onNext(
+                toUserResponse(saved, FriendshipStatus.FRIEND)
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Transactional
+    @Override
+    public void declineFriendshipRequest(FriendshipRequest request, StreamObserver<UserResponse> responseObserver) {
+        if (Objects.equals(request.getUsername(), request.getTargetUsername())) {
+            throw new SameUsernameException("Can`t decline friendship request for self user");
+        }
+        UserEntity currentUser = getRequiredUser(request.getUsername());
+        UserEntity targetUser = getRequiredUser(request.getTargetUsername());
+
+        currentUser.removeInvites(targetUser);
+        targetUser.removeFriends(currentUser);
+
+        userRepository.save(currentUser);
+        UserEntity savedTargetUser = userRepository.save(targetUser);
+
+        responseObserver.onNext(
+                toUserResponse(savedTargetUser)
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Transactional
+    @Override
+    public void removeFriend(FriendshipRequest request, StreamObserver<Empty> responseObserver) {
+        if (Objects.equals(request.getUsername(), request.getTargetUsername())) {
+            throw new SameUsernameException("Can`t remove friendship relation for self user");
+        }
+        UserEntity currentUser = getRequiredUser(request.getUsername());
+        UserEntity targetUser = getRequiredUser(request.getTargetUsername());
+
+        currentUser.removeFriends(targetUser);
+        currentUser.removeInvites(targetUser);
+        targetUser.removeFriends(currentUser);
+        targetUser.removeInvites(currentUser);
+
+        userRepository.save(currentUser);
+        userRepository.save(targetUser);
+
+        responseObserver.onNext(
+                Empty.getDefaultInstance()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Nonnull
+    UserEntity getRequiredUser(@Nonnull String username) {
+        return userRepository.findByUsername(username).orElseThrow(
+                () -> new NotFoundException("Can`t find user by username: '" + username + "'")
+        );
+    }
+
+}

--- a/niffler-userdata/src/main/resources/application.yaml
+++ b/niffler-userdata/src/main/resources/application.yaml
@@ -1,7 +1,14 @@
 server:
   port: 8089
+  grpc:
+    server:
+      port: 8094
 
 spring:
+  grpc:
+    server:
+      servlet:
+        enabled: false
   application:
     name: niffler-userdata
   datasource:


### PR DESCRIPTION
feat: Integrate gRPC support into userdata service and add corresponding tests

Extend configuration to include gRPC addresses and ports for userdata and currency services. Implement gRPC service definitions for user-related operations (e.g., friendship management). Add a gRPC console interceptor utility for logging. Provide JUnit-based gRPC tests for the userdata service, including friendship-related actions. Update entity models and repositories to support new gRPC functionalities. Update application configuration files to include gRPC server settings. This enhancement enables efficient inter-service communication via gRPC, improves testing coverage, and lays the groundwork for further microservice integrations.