### PR TITLE
[TASK ####] homework 18-2

### DIFF
--- a/niffler-e-2-e-tests/build.gradle
+++ b/niffler-e-2-e-tests/build.gradle
@@ -53,7 +53,7 @@ xjcGeneration {
     schemas {
         wsdlSchema {
             schemaFile = 'userdata.wsdl'
-            javaPackageName = 'jaxb.userdata'
+            javaPackageName = 'guru.qa.jaxb.userdata'
             sourceSet = 'test'
         }
     }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/UserdataSoapApi.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/UserdataSoapApi.java
@@ -1,0 +1,70 @@
+package guru.qa.niffler.api;
+
+import jaxb.userdata.*;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+
+public interface UserdataSoapApi {
+
+
+    @Headers(value= {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UserResponse> currentUser(@Body CurrentUserRequest currentUserRequest);
+
+
+    @Headers(value= {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UsersResponse> allUsersPage(@Body AllUsersPageRequest allUsersPageRequest);
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UsersResponse> friendsPage(@Body FriendsPageRequest friendsPageRequest);
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UsersResponse> friends(@Body FriendsRequest friendsRequest);
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<Void> removeFriend(@Body RemoveFriendRequest removeFriendRequest);
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UserResponse> acceptFriend(@Body AcceptInvitationRequest acceptInvitationRequest);
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UserResponse> declineFriend(@Body DeclineInvitationRequest declineInvitationRequest);
+
+
+    @Headers(value = {
+            "Content-type: text/xml",
+            "Accept-Charset: utf-8"
+    })
+    @POST("ws")
+    Call<UserResponse> addFriend(@Body SendInvitationRequest sendInvitationRequest);
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapConverterFactory.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapConverterFactory.java
@@ -1,0 +1,63 @@
+package guru.qa.niffler.api.core.converter;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class SoapConverterFactory  extends Converter.Factory {
+    public static final MediaType XML = MediaType.get("application/xml; charset=utf-8");
+
+    public static SoapConverterFactory create(@Nonnull String namespace) {
+        return new SoapConverterFactory(null, namespace);
+    }
+
+    public static SoapConverterFactory create(@Nonnull JAXBContext context, @Nonnull String namespace ) {
+        return new SoapConverterFactory(context, namespace);
+    }
+    private final @Nullable JAXBContext context;
+    private final @Nonnull String namespace;
+
+  private SoapConverterFactory(@Nullable JAXBContext context, @Nonnull String namespace) {
+        this.context = context;
+        this.namespace = namespace;
+    }
+
+    @Override
+    public @Nullable Converter<?, RequestBody> requestBodyConverter(
+            Type type,
+            Annotation[] parameterAnnotations,
+            Annotation[] methodAnnotations,
+            Retrofit retrofit) {
+        if (type instanceof Class && ((Class<?>) type).isAnnotationPresent(XmlRootElement.class)) {
+            return new SoapRequestConverter<>(contextForType((Class<?>) type), namespace);
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable Converter<ResponseBody, ?> responseBodyConverter(
+            Type type, Annotation[] annotations, Retrofit retrofit) {
+        if (type instanceof Class && ((Class<?>) type).isAnnotationPresent(XmlRootElement.class)) {
+            return new SoapResponseConverter<>(contextForType((Class<?>) type), (Class<?>) type);
+        }
+        return null;
+    }
+
+    private JAXBContext contextForType(Class<?> type) {
+        try {
+            return context != null ? context : JAXBContext.newInstance(type);
+        } catch (JAXBException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapRequestConverter.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapRequestConverter.java
@@ -1,0 +1,53 @@
+package guru.qa.niffler.api.core.converter;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+import okhttp3.RequestBody;
+import org.w3c.dom.Document;
+import retrofit2.Converter;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLOutputFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static guru.qa.niffler.api.core.converter.SoapConverterFactory.XML;
+
+public class SoapRequestConverter<T> implements Converter<T, RequestBody> {
+    final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
+    final JAXBContext context;
+    final String namespace;
+
+    SoapRequestConverter(JAXBContext context, String namespace) {
+        this.context = context;
+        this.namespace = namespace;
+    }
+
+    @Override
+    public RequestBody convert(final T value) throws IOException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            SOAPMessage message = MessageFactory.newInstance().createMessage();
+            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.marshal(value, document);
+
+            message.getSOAPBody().addDocument(document);
+
+            SOAPEnvelope soapEnvelope = message.getSOAPPart().getEnvelope();
+            soapEnvelope.addNamespaceDeclaration("tns", namespace);
+
+            message.writeTo(os);
+
+            return RequestBody.create(XML, os.toByteArray());
+        } catch (SOAPException | ParserConfigurationException | JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapResponseConverter.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/api/core/converter/SoapResponseConverter.java
@@ -1,0 +1,47 @@
+package guru.qa.niffler.api.core.converter;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.MimeHeaders;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+import okhttp3.ResponseBody;
+import org.w3c.dom.Document;
+import retrofit2.Converter;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+final class SoapResponseConverter<T> implements Converter<ResponseBody, T> {
+    final JAXBContext context;
+    final Class<T> type;
+
+    SoapResponseConverter(JAXBContext context, Class<T> type) {
+        this.context = context;
+        this.type = type;
+
+    }
+
+    @Override
+    public T convert(ResponseBody value) throws IOException {
+        try (value;
+             InputStream is = value.byteStream()) {
+            MimeHeaders header = new MimeHeaders();
+            if (value.contentType() != null) {
+                header.addHeader("Content-type", value.contentType().toString());
+            }
+
+            try {
+                SOAPMessage response = MessageFactory.newInstance().createMessage(
+                        header, is
+                );
+                Document document = response.getSOAPBody().extractContentAsDocument();
+
+                return context.createUnmarshaller().unmarshal(document, type).getValue();
+            } catch (SOAPException | JAXBException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/jupiter/annotation/meta/SoapTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/jupiter/annotation/meta/SoapTest.java
@@ -1,0 +1,25 @@
+package guru.qa.niffler.jupiter.annotation.meta;
+
+import guru.qa.niffler.jupiter.extension.CategoryExtension;
+import guru.qa.niffler.jupiter.extension.IssueExtension;
+import guru.qa.niffler.jupiter.extension.SpendingExtension;
+import guru.qa.niffler.jupiter.extension.UserExtension;
+import io.qameta.allure.junit5.AllureJunit5;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith({
+        IssueExtension.class,
+        AllureJunit5.class,
+        UserExtension.class,
+        CategoryExtension.class,
+        SpendingExtension.class,
+})
+public @interface SoapTest {
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/impl/UserdataSoapClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/impl/UserdataSoapClient.java
@@ -1,0 +1,129 @@
+package guru.qa.niffler.service.impl;
+
+import guru.qa.niffler.api.UserdataSoapApi;
+import guru.qa.niffler.api.core.RestClient;
+import guru.qa.niffler.api.core.converter.SoapConverterFactory;
+import guru.qa.niffler.config.Config;
+import io.qameta.allure.Step;
+import jaxb.userdata.*;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.jetbrains.annotations.NotNull;
+import retrofit2.Response;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.IOException;
+
+@ParametersAreNonnullByDefault
+public class UserdataSoapClient extends RestClient {
+
+    private static final Config CFG = Config.getInstance();
+
+    private final UserdataSoapApi userdataSoapApi;
+
+    public UserdataSoapClient() {
+        super(CFG.userdataUrl(), false, SoapConverterFactory.create("niffler-userdata"), HttpLoggingInterceptor.Level.BODY);
+        this.userdataSoapApi = create(UserdataSoapApi.class);
+    }
+
+    @Step("Get Current user info using SOAP")
+    @NotNull
+    public UserResponse currentUser(CurrentUserRequest currentUserRequest) throws IOException {
+
+        return userdataSoapApi.currentUser(currentUserRequest).execute().body();
+
+    }
+
+    @NotNull
+    @Step("Get Page list of users")
+    public UsersResponse allUsersPage(AllUsersPageRequest request) {
+        Response<UsersResponse> response;
+
+        try {
+            response = userdataSoapApi.allUsersPage(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+
+    @NotNull
+    @Step("Get Page list of friends")
+    public UsersResponse friendsPage(FriendsPageRequest request) {
+        Response<UsersResponse> response;
+
+        try {
+            response = userdataSoapApi.friendsPage(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+
+    @NotNull
+    @Step("Get list of friends")
+    public UsersResponse friends(FriendsRequest request) {
+        Response<UsersResponse> response;
+
+        try {
+            response = userdataSoapApi.friends(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+
+    @NotNull
+    @Step("Remove friend")
+    public void removeFriend(RemoveFriendRequest request) {
+        try {
+            userdataSoapApi.removeFriend(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    @Step("Accept friend")
+    public UserResponse acceptFriend(AcceptInvitationRequest request) {
+        Response<UserResponse> response;
+
+        try {
+            response = userdataSoapApi.acceptFriend(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+
+    @NotNull
+    @Step("Decline friend")
+    public UserResponse declineFriend(DeclineInvitationRequest request) {
+        Response<UserResponse> response;
+
+        try {
+            response = userdataSoapApi.declineFriend(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+
+    @NotNull
+    @Step("Add friend")
+    public UserResponse addFriend(SendInvitationRequest request) {
+        Response<UserResponse> response;
+
+        try {
+            response = userdataSoapApi.addFriend(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assert response.body() != null;
+        return response.body();
+    }
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/soap/SoapUsersTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/soap/SoapUsersTest.java
@@ -1,0 +1,161 @@
+package guru.qa.niffler.test.soap;
+
+import guru.qa.niffler.jupiter.annotation.User;
+import guru.qa.niffler.jupiter.annotation.meta.SoapTest;
+import guru.qa.niffler.model.rest.UserJson;
+import guru.qa.niffler.service.impl.UserdataSoapClient;
+import jaxb.userdata.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static guru.qa.niffler.model.FriendshipStatus.INVITE_SENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SoapTest
+public class SoapUsersTest {
+
+
+    private final UserdataSoapClient userdataSoapClient = new UserdataSoapClient();
+
+
+    @Test
+    @User
+    void currentUserTest(UserJson user) throws IOException {
+        CurrentUserRequest request = new CurrentUserRequest();
+        request.setUsername(user.username());
+        UserResponse response = userdataSoapClient.currentUser(request);
+        assertEquals(
+                user.username(),
+                response.getUser().getUsername()
+        );
+    }
+
+    @Test
+    @User(friends = 5)
+    void shouldReturnFriendsListPage(UserJson user) {
+        final FriendsPageRequest request = new FriendsPageRequest();
+        request.setUsername(user.username());
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setPage(0);
+        pageInfo.setSize(5);
+        request.setPageInfo(pageInfo);
+
+        UsersResponse userPageResponse = userdataSoapClient.friendsPage(request);
+
+        assertEquals(5, userPageResponse.getUser().size());
+        assertEquals(5, userPageResponse.getTotalElements());
+        assertEquals(1, userPageResponse.getTotalPages());
+    }
+
+    @Test
+    @User(friends = 5)
+    void shouldReturnFriendFilteredByUsername(UserJson user) {
+        final String expectedUsername = user.testData().friendsUsernames()[0];
+        final FriendsPageRequest request = new FriendsPageRequest();
+        request.setUsername(user.username());
+        request.setSearchQuery(expectedUsername);
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setPage(0);
+        pageInfo.setSize(5);
+        request.setPageInfo(pageInfo);
+
+        UsersResponse userPageResponse = userdataSoapClient.friendsPage(request);
+
+        assertEquals(expectedUsername, userPageResponse.getUser().getFirst().getUsername());
+        assertEquals(1, userPageResponse.getUser().size());
+    }
+
+    @Test
+    @User(friends = 1)
+    void shouldRemoveFriendship(UserJson user) {
+        final String friendToRemove = user.testData().friendsUsernames()[0];
+
+        final RemoveFriendRequest removeRequest = new RemoveFriendRequest();
+        removeRequest.setUsername(user.username());
+        removeRequest.setFriendToBeRemoved(friendToRemove);
+
+        userdataSoapClient.removeFriend(removeRequest);
+
+        UsersResponse friendFilteredResponse = getFriendByUsername(
+                user.username(),
+                friendToRemove
+        );
+        assertEquals(0, friendFilteredResponse.getUser().size());
+    }
+
+    @Test
+    @User(incomeInvitations = 1)
+    void shouldAcceptFriendship(UserJson user) {
+        final UserJson friendToAccept = user.testData().incomeInvitations().get(0);
+        final AcceptInvitationRequest removeRequest = new AcceptInvitationRequest();
+        removeRequest.setUsername(user.username());
+        removeRequest.setFriendToBeAdded(friendToAccept.username());
+
+        userdataSoapClient.acceptFriend(removeRequest);
+
+        UsersResponse friendFilteredResponse = getFriendByUsername(
+                user.username(),
+                friendToAccept.username()
+        );
+
+        assertEquals(
+                friendToAccept.username(),
+                friendFilteredResponse.getUser().getFirst().getUsername()
+        );
+    }
+
+    @Test
+    @User(incomeInvitations = 1)
+    void shouldDeclineFriendship(UserJson user) {
+        final UserJson friendToDecline = user.testData().incomeInvitations().get(0);
+        final DeclineInvitationRequest declineRequest = new DeclineInvitationRequest();
+        declineRequest.setUsername(user.username());
+        declineRequest.setInvitationToBeDeclined(friendToDecline.username());
+
+        userdataSoapClient.declineFriend(declineRequest);
+
+        UsersResponse friendFilteredResponse = getFriendByUsername(
+                user.username(),
+                friendToDecline.username()
+        );
+
+        assertEquals(0, friendFilteredResponse.getUser().size());
+    }
+
+    @Test
+    @User
+    void sendFriendshipRequest(UserJson user) {
+        final AllUsersPageRequest request = new AllUsersPageRequest();
+        request.setUsername(user.username());
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setPage(0);
+        pageInfo.setSize(5);
+        request.setPageInfo(pageInfo);
+
+        final String targetUsername = userdataSoapClient.allUsersPage(request)
+                .getUser().getLast().getUsername();
+
+        final SendInvitationRequest friendshipRequest = new SendInvitationRequest();
+        friendshipRequest.setUsername(user.username());
+        friendshipRequest.setFriendToBeRequested(targetUsername);
+
+        UserResponse userResponse = userdataSoapClient.addFriend(friendshipRequest);
+
+        assertEquals(
+                targetUsername,
+                userResponse.getUser().getUsername()
+        );
+        assertEquals(
+                FriendshipStatus.valueOf(INVITE_SENT.name()),
+                userResponse.getUser().getFriendshipStatus()
+        );
+    }
+
+    private UsersResponse getFriendByUsername(String username, String targetUsername) {
+        final FriendsRequest friendRequest = new FriendsRequest();
+        friendRequest.setUsername(username);
+        friendRequest.setSearchQuery(targetUsername);
+        return userdataSoapClient.friends(friendRequest);
+    }
+}


### PR DESCRIPTION
feat: Migrate Userdata API from REST to SOAP

     - Updated JAXB package structure to 'guru.qa.jaxb.userdata'
     - Replaced REST interface with SOAP interface for Userdata API
     - Implemented SOAP converters (factory, request, response)
     - Added SOAP-specific HTTP headers and XML processing
     - Renamed test annotation to @SoapTest
     - Rewrote Userdata client to use SOAP bindings
     - Updated tests to use new SOAP client and request objects